### PR TITLE
Fix lateinit

### DIFF
--- a/android/src/main/kotlin/com/media/storage/media_storage/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/media/storage/media_storage/MethodCallHandlerImpl.kt
@@ -93,8 +93,8 @@ class MethodCallHandlerImpl(private val context: Context) :
 				result.success(getMediaStoreData(call.argument<String>("path")))
 			}
 			"deleteFile" ->{
-				mresult =result
-				deleteFile(call.argument<String>("deletepath"),mresult!!)
+				//mresult =result
+				deleteFile(call.argument<String>("deletepath"),result)
 			}
 			/*"deleteDir" ->{
 				mresult =result
@@ -102,8 +102,8 @@ class MethodCallHandlerImpl(private val context: Context) :
 
 			}*/
 			"createDirectory" ->{
-				mresult =result
-				createDirectory(call.argument<String>("createfolderpath"),call.argument<String>("foldername"),mresult!!)
+				//mresult =result
+				createDirectory(call.argument<String>("createfolderpath"),call.argument<String>("foldername"),result)
 			}
 
 
@@ -285,10 +285,12 @@ class MethodCallHandlerImpl(private val context: Context) :
 	override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
 		if (resultCode == Activity.RESULT_OK && requestCode == DELETE_PERMISSION_REQUEST) {
 			mresult?.success(true)
+			mresult = null
 
 			Log.e(TAG, "onActivityResult: " )
 		}else{
 			mresult?.success(false)
+			mresult = null
 		}
 		return isDeleted
 	}

--- a/android/src/main/kotlin/com/media/storage/media_storage/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/media/storage/media_storage/MethodCallHandlerImpl.kt
@@ -57,7 +57,7 @@ class MethodCallHandlerImpl(private val context: Context) :
 	var al_filepath: ArrayList<String> = ArrayList<String>()
 
 	val allDatamodel: AllData = AllData()
-	lateinit var mresult: MethodChannel.Result
+	var mresult: MethodChannel.Result? = null
 
 	var allDataList: ArrayList<AllData> = ArrayList<AllData>()
 	private var TAG: String = "MethodCallHandlerImpl"
@@ -94,7 +94,7 @@ class MethodCallHandlerImpl(private val context: Context) :
 			}
 			"deleteFile" ->{
 				mresult =result
-				deleteFile(call.argument<String>("deletepath"),mresult)
+				deleteFile(call.argument<String>("deletepath"),mresult!!)
 			}
 			/*"deleteDir" ->{
 				mresult =result
@@ -103,7 +103,7 @@ class MethodCallHandlerImpl(private val context: Context) :
 			}*/
 			"createDirectory" ->{
 				mresult =result
-				createDirectory(call.argument<String>("createfolderpath"),call.argument<String>("foldername"),mresult)
+				createDirectory(call.argument<String>("createfolderpath"),call.argument<String>("foldername"),mresult!!)
 			}
 
 
@@ -284,11 +284,11 @@ class MethodCallHandlerImpl(private val context: Context) :
 
 	override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
 		if (resultCode == Activity.RESULT_OK && requestCode == DELETE_PERMISSION_REQUEST) {
-			mresult.success(true)
+			mresult?.success(true)
 
 			Log.e(TAG, "onActivityResult: " )
 		}else{
-			mresult.success(false)
+			mresult?.success(false)
 		}
 		return isDeleted
 	}


### PR DESCRIPTION
I've encountered several problems when other app/activity (Google login, Facebook login, Camera, Image gallery, ...) is started from Flutter app which uses media_storage. When the called application ends and returns to my app, the app crashed either with error that late init variable `mresult` was not initialized and used in com.media.storage.media_storage.MethodCallHandlerImpl#onActivityResult line 291. When I fixed this by removing lateinit and setting `mresult` as nullable `MethodChannel.Result?` there was another error on the same place, that the `mresult.success()` was already called.
I'm not sure how it's expected to work, but I changed the code so `mresult` is not set and thus not used. It works in my apps - I get Google login, get photos from camera and gallery.
Maybe there could be some issues with my patch, but until I encouter one, I cannot fix it.